### PR TITLE
Add additional check if `Devices` is present in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ LiftMasterPlatform.prototype.getDevice = function (callback) {
   }).then(function (res) {
     return res.json();
   }).then(function (data) {
-    if (data.ReturnCode === "0") {
+    if (data.ReturnCode === "0" && data.Devices) {
       var devices = data.Devices;
 
       // Look through the array of devices for all the gateways


### PR DESCRIPTION
The whole homebridge instance got corrupted in my case when ReturnCode was `0`
but there was not `Devices` in the data. Adding additional check will put a regular error
message in log and not affect homebridge instance:

```
[Garage Door] Error getting MyQ devices: please contact customer care, supportID: xxx
```